### PR TITLE
Replace custom action with Wix IIS extension for certificate import

### DIFF
--- a/BatterySimulatorMSI/BatterySimulatorMSI.wixproj
+++ b/BatterySimulatorMSI/BatterySimulatorMSI.wixproj
@@ -38,6 +38,10 @@
     </WixLibrary>
   </ItemGroup>
   <ItemGroup>
+    <WixExtension Include="WixIIsExtension">
+      <HintPath>$(WixExtDir)\WixIIsExtension.dll</HintPath>
+      <Name>WixIIsExtension</Name>
+    </WixExtension>
     <WixExtension Include="WixDifxAppExtension">
       <HintPath>$(WixExtDir)\WixDifxAppExtension.dll</HintPath>
       <Name>WixDifxAppExtension</Name>

--- a/BatterySimulatorMSI/Product.wxs
+++ b/BatterySimulatorMSI/Product.wxs
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:difxapp='http://schemas.microsoft.com/wix/DifxAppExtension'>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:difxapp='http://schemas.microsoft.com/wix/DifxAppExtension' xmlns:iis="http://schemas.microsoft.com/wix/IIsExtension">
     <Product Id="*" Name="BatterySimulator" Language="1033" Version="1.0.0.0" Manufacturer="TODO-Set-Manufacturer" UpgradeCode="E1C79D1B-49A9-45F8-AC07-2762C3B20005">
         <Package InstallerVersion="500" Compressed="yes" InstallScope="perMachine" Description="Simulated battery driver" />
 
@@ -11,24 +11,6 @@
         <Feature Id="ProductFeature" Title="BatterySimulator" Level="1">
             <ComponentGroupRef Id="ProductComponents" />
         </Feature>
-
-        <CustomAction Id="AddCertToRoot"
-                  Directory="INSTALLFOLDER"
-                  ExeCommand="certutil.exe -addstore root &quot;[INSTALLFOLDER]simbatt.cer&quot;"
-                  Execute="deferred"
-                  Impersonate="no"
-                  />
-        <CustomAction Id="AddCertToTrustedPublisher"
-                  Directory="INSTALLFOLDER"
-                  ExeCommand="certutil.exe -addstore trustedpublisher &quot;[INSTALLFOLDER]simbatt.cer&quot;"
-                  Execute="deferred"
-                  Impersonate="no"
-                  />
-
-        <InstallExecuteSequence>
-            <Custom Action='AddCertToRoot' Before='MsiProcessDrivers'>NOT Installed OR REINSTALL</Custom>
-            <Custom Action='AddCertToTrustedPublisher' Before='MsiProcessDrivers'>NOT Installed OR REINSTALL</Custom>
-        </InstallExecuteSequence>
     </Product>
 
     <Fragment>
@@ -40,18 +22,18 @@
     </Fragment>
 
     <Fragment>
+        <Binary Id="DriverCert" SourceFile="$(var.simbatt.TargetDir)simbatt\simbatt.cer" />
         <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
-            <Component Id="Certificate" Guid="*">
-                <File Id="simbatt.cer" Source="$(var.simbatt.TargetDir)simbatt\simbatt.cer" KeyPath="yes"/>
+            <Component Id="CertAndDevGen" Guid="*">
+                <iis:Certificate Id="root" Name="simbatt.cer" Overwrite="no" StoreLocation="localMachine" StoreName="root" BinaryKey="DriverCert" />
+                <iis:Certificate Id="trustedPublisher" Name="simbatt.cer" Overwrite="no" StoreLocation="localMachine" StoreName="trustedPublisher" BinaryKey="DriverCert" />
+                <File Id="devgen.exe" Source="$(var.simbatt.TargetDir)simbatt\devgen.exe" KeyPath="yes" Checksum="yes"/>
             </Component>
             <Component Id="DriverFiles" Guid="*">
                 <difxapp:Driver Legacy='yes' PlugAndPlayPrompt='no' />
                 <File Id="simbatt.cat" Source="$(var.simbatt.TargetDir)simbatt\simbatt.cat" />
                 <File Id="simbatt.inf" Source="$(var.simbatt.TargetDir)simbatt\simbatt.inf" />
                 <File Id="simbatt.sys" Source="$(var.simbatt.TargetDir)simbatt\simbatt.sys" KeyPath="yes" Checksum="yes"/>
-            </Component>
-            <Component Id="DevGen" Guid="*">
-                <File Id="devgen.exe" Source="$(var.simbatt.TargetDir)simbatt\devgen.exe" KeyPath="yes" Checksum="yes"/>
             </Component>
         </ComponentGroup>
     </Fragment>


### PR DESCRIPTION
PROBLEM: Certificate is always _deleted_ on uninstall, regardless if it was added before this MSI was installed.