### PR TITLE
Stop making many of the functions pageable to simplify

### DIFF
--- a/simbatt/miniclass.c
+++ b/simbatt/miniclass.c
@@ -115,7 +115,6 @@ SaveSimBattStateToRegistry (
 
 //---------------------------------------------------------------------- Pragmas
 
-#pragma alloc_text(PAGE, SimBattUpdateTag)
 #pragma alloc_text(PAGE, SimBattQueryTag)
 #pragma alloc_text(PAGE, SimBattQueryInformation)
 #pragma alloc_text(PAGE, SimBattQueryStatus)
@@ -203,29 +202,16 @@ VOID
 SimBattUpdateTag (
     PSIMBATT_FDO_DATA DevExt
     )
-
 /*++
-
 Routine Description:
-
     This routine is called when static battery properties have changed to
     update the battery tag.
 
 Arguments:
-
     DevExt - Supplies a pointer to the device extension  of the battery to
         update.
-
-Return Value:
-
-    None
-
 --*/
-
 {
-
-    PAGED_CODE();
-
     DevExt->BatteryTag += 1;
     if (DevExt->BatteryTag == BATTERY_TAG_INVALID) {
         DevExt->BatteryTag += 1;

--- a/simbatt/miniclass.c
+++ b/simbatt/miniclass.c
@@ -115,7 +115,6 @@ SaveSimBattStateToRegistry (
 
 //---------------------------------------------------------------------- Pragmas
 
-#pragma alloc_text(PAGE, SimBattPrepareHardware)
 #pragma alloc_text(PAGE, SimBattUpdateTag)
 #pragma alloc_text(PAGE, SimBattQueryTag)
 #pragma alloc_text(PAGE, SimBattQueryInformation)
@@ -141,37 +140,22 @@ VOID
 SimBattPrepareHardware (
     WDFDEVICE Device
     )
-
 /*++
-
 Routine Description:
-
     This routine is called to initialize battery data to sane values.
 
     A real battery would query hardware to determine if a battery is present,
     query its static capabilities, etc.
 
 Arguments:
-
     Device - Supplies the device to initialize.
-
-Return Value:
-
-    NTSTATUS
-
 --*/
-
 {
-    PSIMBATT_FDO_DATA DevExt;
-
     DebugEnter();
-    PAGED_CODE();
 
-    DevExt = GetDeviceExtension(Device);
+    PSIMBATT_FDO_DATA DevExt = GetDeviceExtension(Device);
 
-    //
     // Get this battery's state - use defaults.
-    //
 
     {
         WdfWaitLockAcquire(DevExt->StateLock, NULL);

--- a/simbatt/miniclass.c
+++ b/simbatt/miniclass.c
@@ -115,7 +115,6 @@ SaveSimBattStateToRegistry (
 
 //---------------------------------------------------------------------- Pragmas
 
-#pragma alloc_text(PAGE, SimBattQueryTag)
 #pragma alloc_text(PAGE, SimBattQueryInformation)
 #pragma alloc_text(PAGE, SimBattQueryStatus)
 #pragma alloc_text(PAGE, SimBattSetStatusNotify)
@@ -226,33 +225,21 @@ SimBattQueryTag (
     PVOID Context,
     PULONG BatteryTag
     )
-
 /*++
-
 Routine Description:
-
     This routine is called to get the value of the current battery tag.
 
 Arguments:
-
     Context - Supplies the miniport context value for battery
 
     BatteryTag - Supplies a pointer to a ULONG to receive the battery tag.
-
-Return Value:
-
-    NTSTATUS
-
 --*/
-
 {
-    PSIMBATT_FDO_DATA DevExt;
     NTSTATUS Status;
 
     DebugEnter();
-    PAGED_CODE();
 
-    DevExt = (PSIMBATT_FDO_DATA)Context;
+    PSIMBATT_FDO_DATA DevExt = (PSIMBATT_FDO_DATA)Context;
     WdfWaitLockAcquire(DevExt->StateLock, NULL);
     *BatteryTag = DevExt->BatteryTag;
     WdfWaitLockRelease(DevExt->StateLock);

--- a/simbatt/miniclass.c
+++ b/simbatt/miniclass.c
@@ -115,7 +115,6 @@ SaveSimBattStateToRegistry (
 
 //---------------------------------------------------------------------- Pragmas
 
-#pragma alloc_text(PAGE, SimBattSetBatteryString)
 #pragma alloc_text(PAGE, SimBattGetBatteryMaxChargingCurrent)
 #pragma alloc_text(PAGE, SaveSimBattStateToRegistry)
 
@@ -1107,29 +1106,16 @@ SimBattSetBatteryString (
     PCWSTR String,
     PWCHAR Destination
     )
-
 /*++
-
 Routine Description:
-
     Set one of the simulated battery strings.
 
 Arguments:
-
     String - Supplies the new string value to set.
 
     Destination - Supplies a pointer to the buffer to store the new string.
-
-Return Value:
-
-   NTSTATUS
-
 --*/
-
 {
-
-    PAGED_CODE();
-
     return RtlStringCchCopyW(Destination, MAX_BATTERY_STRING_SIZE, String);
 }
 

--- a/simbatt/miniclass.c
+++ b/simbatt/miniclass.c
@@ -115,7 +115,6 @@ SaveSimBattStateToRegistry (
 
 //---------------------------------------------------------------------- Pragmas
 
-#pragma alloc_text(PAGE, SimBattSetBatteryManufactureDate)
 #pragma alloc_text(PAGE, SimBattSetBatteryGranularityScale)
 #pragma alloc_text(PAGE, SimBattSetBatteryEstimatedTime)
 #pragma alloc_text(PAGE, SimBattSetBatteryTemperature)
@@ -951,34 +950,18 @@ SimBattSetBatteryManufactureDate (
     WDFDEVICE Device,
     PBATTERY_MANUFACTURE_DATE ManufactureDate
     )
-
 /*++
-
 Routine Description:
-
     Set the simulated battery manufacture date structure values.
 
 Arguments:
-
     Device - Supplies the device to set data for.
 
     ManufactureDate - Supplies the new manufacture date to set.
-
-Return Value:
-
-   NTSTATUS
-
 --*/
-
 {
-
-    PSIMBATT_FDO_DATA DevExt;
-    NTSTATUS Status;
-
-    PAGED_CODE();
-
-    Status = STATUS_INVALID_PARAMETER;
-    DevExt = GetDeviceExtension(Device);
+    NTSTATUS Status = STATUS_INVALID_PARAMETER;
+    PSIMBATT_FDO_DATA DevExt = GetDeviceExtension(Device);
     if ((ManufactureDate->Year == 0) ||
         (ManufactureDate->Month == 0) ||
         (ManufactureDate->Day == 0)) {

--- a/simbatt/miniclass.c
+++ b/simbatt/miniclass.c
@@ -115,7 +115,6 @@ SaveSimBattStateToRegistry (
 
 //---------------------------------------------------------------------- Pragmas
 
-#pragma alloc_text(PAGE, SimBattGetBatteryMaxChargingCurrent)
 #pragma alloc_text(PAGE, SaveSimBattStateToRegistry)
 
 //------------------------------------------------------------ Battery Interface
@@ -1125,36 +1124,19 @@ SimBattGetBatteryMaxChargingCurrent (
     WDFDEVICE Device,
     PULONG MaxChargingCurrent
     )
-
 /*
  Routine Description:
-
     Called by the class driver to get the battery's maximum charging current.
 
 Arguments:
-
     Context - Supplies the miniport context value for battery
 
     MaxChargingCurrent - Supplies the pointer to return the value to
-
-Return Value:
-
-    NTSTATUS
-
 --*/
-
 {
-
-    PSIMBATT_FDO_DATA DevExt;
-    NTSTATUS Status;
-
-    PAGED_CODE();
-
-    DevExt = GetDeviceExtension(Device);
+    PSIMBATT_FDO_DATA DevExt = GetDeviceExtension(Device);
     *MaxChargingCurrent = DevExt->State.MaxCurrentDraw;
-    Status = STATUS_SUCCESS;
-
-    return Status;
+    return STATUS_SUCCESS;
 }
 
 

--- a/simbatt/miniclass.c
+++ b/simbatt/miniclass.c
@@ -115,7 +115,6 @@ SaveSimBattStateToRegistry (
 
 //---------------------------------------------------------------------- Pragmas
 
-#pragma alloc_text(PAGE, SimBattSetBatteryInformation)
 #pragma alloc_text(PAGE, SimBattSetBatteryManufactureDate)
 #pragma alloc_text(PAGE, SimBattSetBatteryGranularityScale)
 #pragma alloc_text(PAGE, SimBattSetBatteryEstimatedTime)
@@ -888,36 +887,19 @@ SimBattSetBatteryInformation (
     WDFDEVICE Device,
     PBATTERY_INFORMATION BatteryInformation
     )
-
 /*++
-
 Routine Description:
-
     Set the simulated battery information structure values.
 
 Arguments:
-
     Device - Supplies the device to set data for.
 
     BatteryInformation - Supplies the new information data to set.
-
-Return Value:
-
-   NTSTATUS
-
 --*/
-
 {
-
-    PSIMBATT_FDO_DATA DevExt;
-    NTSTATUS Status;
-    ULONG ValidCapabilities;
-
-    PAGED_CODE();
-
-    Status = STATUS_INVALID_PARAMETER;
-    DevExt = GetDeviceExtension(Device);
-    ValidCapabilities = BATTERY_CAPACITY_RELATIVE |
+    NTSTATUS Status = STATUS_INVALID_PARAMETER;
+    PSIMBATT_FDO_DATA DevExt = GetDeviceExtension(Device);
+    ULONG ValidCapabilities = BATTERY_CAPACITY_RELATIVE |
                         BATTERY_IS_SHORT_TERM |
                         BATTERY_SYSTEM_BATTERY;
 

--- a/simbatt/miniclass.c
+++ b/simbatt/miniclass.c
@@ -115,7 +115,6 @@ SaveSimBattStateToRegistry (
 
 //---------------------------------------------------------------------- Pragmas
 
-#pragma alloc_text(PAGE, SimBattDisableStatusNotify)
 #pragma alloc_text(PAGE, SimBattSetInformation)
 #pragma alloc_text(PAGE, SimBattIoDeviceControl)
 #pragma alloc_text(PAGE, SimBattSetBatteryStatus)
@@ -543,35 +542,25 @@ NTSTATUS
 SimBattDisableStatusNotify (
     PVOID Context
     )
-
 /*++
-
 Routine Description:
-
     Called by the class driver to disable notification.
 
     The battery class driver will serialize all requests it issues to
     the miniport for a given battery.
 
 Arguments:
-
     Context - Supplies the miniport context value for battery
 
 Return Value:
-
     Success if there is a battery currently installed, else no such device.
-
 --*/
-
 {
-    NTSTATUS Status;
-
     UNREFERENCED_PARAMETER(Context);
 
     DebugEnter();
-    PAGED_CODE();
 
-    Status = STATUS_NOT_SUPPORTED;
+    NTSTATUS Status = STATUS_NOT_SUPPORTED;
     DebugExitStatus(Status);
     return Status;
 }

--- a/simbatt/miniclass.c
+++ b/simbatt/miniclass.c
@@ -115,7 +115,6 @@ SaveSimBattStateToRegistry (
 
 //---------------------------------------------------------------------- Pragmas
 
-#pragma alloc_text(PAGE, SimBattIoDeviceControl)
 #pragma alloc_text(PAGE, SimBattSetBatteryStatus)
 #pragma alloc_text(PAGE, SimBattSetBatteryInformation)
 #pragma alloc_text(PAGE, SimBattSetBatteryManufactureDate)
@@ -626,8 +625,6 @@ SetInformationEnd:
 // implement the control side of the simulated battery. A real battery would
 // not implement this interface, and instead read battery data from hardware/
 // firmware interfaces.
-//
-
 VOID
 SimBattIoDeviceControl (
     WDFQUEUE Queue,
@@ -636,15 +633,11 @@ SimBattIoDeviceControl (
     size_t InputBufferLength,
     ULONG IoControlCode
     )
-
 /*++
-
 Routine Description:
-
     Handle changes to the simulated battery state.
 
 Arguments:
-
     Queue - Supplies a handle to the framework queue object that is associated
         with the I/O request.
 
@@ -659,21 +652,11 @@ Arguments:
 
     IoControlCode - Supplies the Driver-defined or system-defined I/O control
         code (IOCTL) that is associated with the request.
-
-Return Value:
-
-   VOID
-
 --*/
-
 {
-
     PBATTERY_INFORMATION BatteryInformation;
     PBATTERY_STATUS BatteryStatus;
-    ULONG BytesReturned;
     PWCHAR DestinationString;
-    PSIMBATT_FDO_DATA DevExt;
-    WDFDEVICE Device;
     PULONG EstimatedRunTime;
     ULONG GranularityEntries;
     PBATTERY_REPORTING_SCALE GranularityScale;
@@ -687,11 +670,9 @@ Return Value:
 
     UNREFERENCED_PARAMETER(OutputBufferLength);
 
-    PAGED_CODE();
-
-    BytesReturned = 0;
-    Device = WdfIoQueueGetDevice(Queue);
-    DevExt = GetDeviceExtension(Device);
+    ULONG BytesReturned = 0;
+    WDFDEVICE Device = WdfIoQueueGetDevice(Queue);
+    PSIMBATT_FDO_DATA DevExt = GetDeviceExtension(Device);
     DebugPrint(SIMBATT_INFO, "SimBattIoDeviceControl: 0x%p\n", Device);
     Status = STATUS_INVALID_PARAMETER;
     switch (IoControlCode) {

--- a/simbatt/miniclass.c
+++ b/simbatt/miniclass.c
@@ -115,7 +115,6 @@ SaveSimBattStateToRegistry (
 
 //---------------------------------------------------------------------- Pragmas
 
-#pragma alloc_text(PAGE, SimBattSetBatteryStatus)
 #pragma alloc_text(PAGE, SimBattSetBatteryInformation)
 #pragma alloc_text(PAGE, SimBattSetBatteryManufactureDate)
 #pragma alloc_text(PAGE, SimBattSetBatteryGranularityScale)
@@ -849,36 +848,19 @@ SimBattSetBatteryStatus (
     WDFDEVICE Device,
     PBATTERY_STATUS BatteryStatus
     )
-
 /*++
-
 Routine Description:
-
     Set the simulated battery status structure values.
 
 Arguments:
-
     Device - Supplies the device to set data for.
 
     BatteryStatus - Supplies the new status data to set.
-
-Return Value:
-
-   NTSTATUS
-
 --*/
-
 {
-
-    PSIMBATT_FDO_DATA DevExt;
-    NTSTATUS Status;
-    ULONG ValidPowerState;
-
-    PAGED_CODE();
-
-    Status = STATUS_INVALID_PARAMETER;
-    DevExt = GetDeviceExtension(Device);
-    ValidPowerState = BATTERY_CHARGING |
+    NTSTATUS Status = STATUS_INVALID_PARAMETER;
+    PSIMBATT_FDO_DATA DevExt = GetDeviceExtension(Device);
+    ULONG ValidPowerState = BATTERY_CHARGING |
                       BATTERY_DISCHARGING |
                       BATTERY_CRITICAL |
                       BATTERY_POWER_ON_LINE;

--- a/simbatt/miniclass.c
+++ b/simbatt/miniclass.c
@@ -115,7 +115,6 @@ SaveSimBattStateToRegistry (
 
 //---------------------------------------------------------------------- Pragmas
 
-#pragma alloc_text(PAGE, SimBattQueryInformation)
 #pragma alloc_text(PAGE, SimBattQueryStatus)
 #pragma alloc_text(PAGE, SimBattSetStatusNotify)
 #pragma alloc_text(PAGE, SimBattDisableStatusNotify)
@@ -264,11 +263,8 @@ SimBattQueryInformation (
     ULONG BufferLength,
     PULONG ReturnedLength
     )
-
 /*++
-
 Routine Description:
-
     Called by the class driver to retrieve battery information
 
     The battery class driver will serialize all requests it issues to
@@ -278,7 +274,6 @@ Routine Description:
     can't be handled. This is defined in the battery class spec.
 
 Arguments:
-
     Context - Supplies the miniport context value for battery
 
     BatteryTag - Supplies the tag of current battery
@@ -294,11 +289,8 @@ Arguments:
     ReturnedLength - Supplies the length in bytes of the returned data
 
 Return Value:
-
     Success if there is a battery currently installed, else no such device.
-
 --*/
-
 {
     PSIMBATT_FDO_DATA DevExt;
     ULONG ResultValue;
@@ -309,7 +301,6 @@ Return Value:
     UNREFERENCED_PARAMETER(AtRate);
 
     DebugEnter();
-    PAGED_CODE();
 
     DevExt = (PSIMBATT_FDO_DATA)Context;
     WdfWaitLockAcquire(DevExt->StateLock, NULL);

--- a/simbatt/miniclass.c
+++ b/simbatt/miniclass.c
@@ -115,7 +115,6 @@ SaveSimBattStateToRegistry (
 
 //---------------------------------------------------------------------- Pragmas
 
-#pragma alloc_text(PAGE, SimBattSetStatusNotify)
 #pragma alloc_text(PAGE, SimBattDisableStatusNotify)
 #pragma alloc_text(PAGE, SimBattSetInformation)
 #pragma alloc_text(PAGE, SimBattIoDeviceControl)
@@ -497,11 +496,8 @@ SimBattSetStatusNotify (
     ULONG BatteryTag,
     PBATTERY_NOTIFY BatteryNotify
     )
-
 /*++
-
 Routine Description:
-
     Called by the class driver to set the capacity and power state levels
     at which the class driver requires notification.
 
@@ -509,7 +505,6 @@ Routine Description:
     the miniport for a given battery.
 
 Arguments:
-
     Context - Supplies the miniport context value for battery
 
     BatteryTag - Supplies the tag of current battery
@@ -518,11 +513,8 @@ Arguments:
         notification critera.
 
 Return Value:
-
     Success if there is a battery currently installed, else no such device.
-
 --*/
-
 {
     PSIMBATT_FDO_DATA DevExt;
     NTSTATUS Status;
@@ -530,7 +522,6 @@ Return Value:
     UNREFERENCED_PARAMETER(BatteryNotify);
 
     DebugEnter();
-    PAGED_CODE();
 
     DevExt = (PSIMBATT_FDO_DATA)Context;
     WdfWaitLockAcquire(DevExt->StateLock, NULL);

--- a/simbatt/miniclass.c
+++ b/simbatt/miniclass.c
@@ -115,7 +115,6 @@ SaveSimBattStateToRegistry (
 
 //---------------------------------------------------------------------- Pragmas
 
-#pragma alloc_text(PAGE, SimBattQueryStatus)
 #pragma alloc_text(PAGE, SimBattSetStatusNotify)
 #pragma alloc_text(PAGE, SimBattDisableStatusNotify)
 #pragma alloc_text(PAGE, SimBattSetInformation)
@@ -448,18 +447,14 @@ SimBattQueryStatus (
     ULONG BatteryTag,
     PBATTERY_STATUS BatteryStatus
     )
-
 /*++
-
 Routine Description:
-
     Called by the class driver to retrieve the batteries current status
 
     The battery class driver will serialize all requests it issues to
     the miniport for a given battery.
 
 Arguments:
-
     Context - Supplies the miniport context value for battery
 
     BatteryTag - Supplies the tag of current battery
@@ -468,17 +463,13 @@ Arguments:
         battery status in
 
 Return Value:
-
     Success if there is a battery currently installed, else no such device.
-
 --*/
-
 {
     PSIMBATT_FDO_DATA DevExt;
     NTSTATUS Status;
 
     DebugEnter();
-    PAGED_CODE();
 
     DevExt = (PSIMBATT_FDO_DATA)Context;
     WdfWaitLockAcquire(DevExt->StateLock, NULL);

--- a/simbatt/miniclass.c
+++ b/simbatt/miniclass.c
@@ -115,7 +115,6 @@ SaveSimBattStateToRegistry (
 
 //---------------------------------------------------------------------- Pragmas
 
-#pragma alloc_text(PAGE, SimBattSetInformation)
 #pragma alloc_text(PAGE, SimBattIoDeviceControl)
 #pragma alloc_text(PAGE, SimBattSetBatteryStatus)
 #pragma alloc_text(PAGE, SimBattSetBatteryInformation)
@@ -573,15 +572,12 @@ SimBattSetInformation (
     BATTERY_SET_INFORMATION_LEVEL Level,
     PVOID Buffer
     )
-
 /*
  Routine Description:
-
     Called by the class driver to set the battery's charge/discharge state,
     critical bias, or charge current.
 
 Arguments:
-
     Context - Supplies the miniport context value for battery
 
     BatteryTag - Supplies the tag of current battery
@@ -589,22 +585,14 @@ Arguments:
     Level - Supplies action requested
 
     Buffer - Supplies a critical bias value if level is BatteryCriticalBias.
-
-Return Value:
-
-    NTSTATUS
-
 --*/
-
 {
     PBATTERY_CHARGING_SOURCE ChargingSource;
-    PSIMBATT_FDO_DATA DevExt;
     NTSTATUS Status;
 
     DebugEnter();
-    PAGED_CODE();
 
-    DevExt = (PSIMBATT_FDO_DATA)Context;
+    PSIMBATT_FDO_DATA DevExt = (PSIMBATT_FDO_DATA)Context;
     WdfWaitLockAcquire(DevExt->StateLock, NULL);
     if (BatteryTag != DevExt->BatteryTag) {
         Status = STATUS_NO_SUCH_DEVICE;

--- a/simbatt/miniclass.c
+++ b/simbatt/miniclass.c
@@ -115,7 +115,6 @@ SaveSimBattStateToRegistry (
 
 //---------------------------------------------------------------------- Pragmas
 
-#pragma alloc_text(PAGE, SimBattSetBatteryEstimatedTime)
 #pragma alloc_text(PAGE, SimBattSetBatteryTemperature)
 #pragma alloc_text(PAGE, SimBattSetBatteryString)
 #pragma alloc_text(PAGE, SimBattGetBatteryMaxChargingCurrent)
@@ -1060,35 +1059,20 @@ SimBattSetBatteryEstimatedTime (
     WDFDEVICE Device,
     ULONG EstimatedTime
     )
-
 /*++
-
 Routine Description:
-
     Set the simulated battery estimated charge/run time. The value
     SIMBATT_RATE_CALCULATE causes the estimated time to be calculated based on
     charge/discharge status, the charge/discharge rate, the current capacity,
     and the last full charge capacity.
 
 Arguments:
-
     Device - Supplies the device to set data for.
 
     EstimatedTime - Supplies the new estimated run/charge time to set.
-
-Return Value:
-
-   NTSTATUS
-
 --*/
-
 {
-
-    PSIMBATT_FDO_DATA DevExt;
-
-    PAGED_CODE();
-
-    DevExt = GetDeviceExtension(Device);
+    PSIMBATT_FDO_DATA DevExt = GetDeviceExtension(Device);
     WdfWaitLockAcquire(DevExt->StateLock, NULL);
     DevExt->State.EstimatedTime = EstimatedTime;
     WdfWaitLockRelease(DevExt->StateLock);

--- a/simbatt/miniclass.c
+++ b/simbatt/miniclass.c
@@ -113,10 +113,6 @@ SaveSimBattStateToRegistry (
     _In_ PSIMBATT_STATE State
     );
 
-//---------------------------------------------------------------------- Pragmas
-
-#pragma alloc_text(PAGE, SaveSimBattStateToRegistry)
-
 //------------------------------------------------------------ Battery Interface
 
 _Use_decl_annotations_
@@ -1146,33 +1142,21 @@ SaveSimBattStateToRegistry (
     WDFDEVICE Device,
     PSIMBATT_STATE State
     )
-
 /*
  Routine Description:
-
     Called to save simbatt state data to the registry.
 
 Arguments:
-
     Device - Supplies WDF device handle.
 
     State - Supplies the pointer to the simbatt state.
-
-Return Value:
-
-    NTSTATUS
-
 --*/
-
 {
 
     WDFKEY  KeyHandle;
     DECLARE_CONST_UNICODE_STRING(SimbattStateRegNameStr, SIMBATT_STATE_REG_NAME);
-    NTSTATUS Status;
 
-    PAGED_CODE();
-
-    Status = WdfDeviceOpenRegistryKey(
+    NTSTATUS Status = WdfDeviceOpenRegistryKey(
         Device,
         PLUGPLAY_REGKEY_DEVICE,
         KEY_WRITE,

--- a/simbatt/miniclass.c
+++ b/simbatt/miniclass.c
@@ -115,7 +115,6 @@ SaveSimBattStateToRegistry (
 
 //---------------------------------------------------------------------- Pragmas
 
-#pragma alloc_text(PAGE, SimBattSetBatteryGranularityScale)
 #pragma alloc_text(PAGE, SimBattSetBatteryEstimatedTime)
 #pragma alloc_text(PAGE, SimBattSetBatteryTemperature)
 #pragma alloc_text(PAGE, SimBattSetBatteryString)
@@ -1009,46 +1008,28 @@ SimBattSetBatteryGranularityScale (
     PBATTERY_REPORTING_SCALE Scale,
     ULONG ScaleCount
     )
-
 /*++
-
 Routine Description:
-
     Set the simulated battery status structure values.
 
 Arguments:
-
     Device - Supplies the device to set data for.
 
     Scale - Supplies the new granularity scale to set.
 
     ScaleCount - Supplies the number of granularity scale entries to set.
-
-Return Value:
-
-   NTSTATUS
-
 --*/
-
 {
-
-    PSIMBATT_FDO_DATA DevExt;
     ULONG ScaleIndex;
-    NTSTATUS Status;
 
-    PAGED_CODE();
-
-    Status = STATUS_INVALID_PARAMETER;
-    DevExt = GetDeviceExtension(Device);
+    NTSTATUS Status = STATUS_INVALID_PARAMETER;
+    PSIMBATT_FDO_DATA DevExt = GetDeviceExtension(Device);
     if (ScaleCount > 4) {
         goto SetBatteryGranularityScaleEnd;
     }
 
-    //
     // Scale regions are listed in increasing order of capacity ranges they
     // apply to.
-    //
-
     for (ScaleIndex = 1; ScaleIndex < ScaleCount; ScaleIndex += 1) {
         if (Scale[ScaleIndex].Capacity <= Scale[ScaleIndex - 1].Capacity) {
             goto SetBatteryGranularityScaleEnd;

--- a/simbatt/miniclass.c
+++ b/simbatt/miniclass.c
@@ -115,7 +115,6 @@ SaveSimBattStateToRegistry (
 
 //---------------------------------------------------------------------- Pragmas
 
-#pragma alloc_text(PAGE, SimBattSetBatteryTemperature)
 #pragma alloc_text(PAGE, SimBattSetBatteryString)
 #pragma alloc_text(PAGE, SimBattGetBatteryMaxChargingCurrent)
 #pragma alloc_text(PAGE, SaveSimBattStateToRegistry)
@@ -1085,32 +1084,17 @@ SimBattSetBatteryTemperature (
     WDFDEVICE Device,
     ULONG Temperature
     )
-
 /*++
-
 Routine Description:
-
     Set the simulated battery temperature value.
 
 Arguments:
-
     Device - Supplies the device to set data for.
 
     Temperature - Supplies the new temperature to set.
-
-Return Value:
-
-   NTSTATUS
-
 --*/
-
 {
-
-    PSIMBATT_FDO_DATA DevExt;
-
-    PAGED_CODE();
-
-    DevExt = GetDeviceExtension(Device);
+    PSIMBATT_FDO_DATA DevExt = GetDeviceExtension(Device);
     WdfWaitLockAcquire(DevExt->StateLock, NULL);
     DevExt->State.Temperature = Temperature;
     WdfWaitLockRelease(DevExt->StateLock);

--- a/simbatt/wdf.c
+++ b/simbatt/wdf.c
@@ -36,7 +36,6 @@ WMI_QUERY_DATABLOCK_CALLBACK SimBattQueryWmiDataBlock;
 
 //---------------------------------------------------------------------- Pragmas
 
-#pragma alloc_text(PAGE, SimBattQueryWmiRegInfo)
 #pragma alloc_text(PAGE, SimBattQueryWmiDataBlock)
 
 //-------------------------------------------------------------------- Functions
@@ -680,18 +679,14 @@ SimBattQueryWmiRegInfo (
     PUNICODE_STRING MofResourceName,
     PDEVICE_OBJECT *Pdo
     )
-
 /*++
-
 Routine Description:
-
     This routine is a callback into the driver to retrieve the list of
     guids or data blocks that the driver wants to register with WMI. This
     routine may not pend or block. Driver should NOT call
     WmiCompleteRequest.
 
 Arguments:
-
     DeviceObject - Supplies the device whose data block is being queried.
 
     RegFlags - Supplies a pointer to return a set of flags that describe the
@@ -717,15 +712,8 @@ Arguments:
     Pdo - Supplies a pointer to return the device object for the PDO associated
         with this device if the WMIREG_FLAG_INSTANCE_PDO flag is returned in
         *RegFlags.
-
-Return Value:
-
-    NTSTATUS
-
 --*/
-
 {
-
     WDFDEVICE Device;
     PSIMBATT_GLOBAL_DATA GlobalData;
     NTSTATUS Status;
@@ -734,7 +722,6 @@ Return Value:
     UNREFERENCED_PARAMETER(InstanceName);
 
     DebugEnter();
-    PAGED_CODE();
 
     Device = WdfWdmDeviceGetWdfDeviceHandle(DeviceObject);
     GlobalData = GetGlobalData(WdfGetDriver());

--- a/simbatt/wdf.c
+++ b/simbatt/wdf.c
@@ -34,10 +34,6 @@ EVT_WDFDEVICE_WDM_IRP_PREPROCESS SimBattWdmIrpPreprocessSystemControl;
 WMI_QUERY_REGINFO_CALLBACK SimBattQueryWmiRegInfo;
 WMI_QUERY_DATABLOCK_CALLBACK SimBattQueryWmiDataBlock;
 
-//---------------------------------------------------------------------- Pragmas
-
-#pragma alloc_text(PAGE, SimBattQueryWmiDataBlock)
-
 //-------------------------------------------------------------------- Functions
 
 _Use_decl_annotations_
@@ -745,18 +741,14 @@ SimBattQueryWmiDataBlock (
     ULONG BufferAvail,
     PUCHAR Buffer
     )
-
 /*++
-
 Routine Description:
-
     This routine is a callback into the driver to query for the contents of
     a data block. When the driver has finished filling the data block it
     must call WmiCompleteRequest to complete the irp. The driver can
     return STATUS_PENDING if the irp cannot be completed immediately.
 
 Arguments:
-
     DeviceObject - Supplies the device whose data block is being queried.
 
     Irp - Supplies the Irp that makes this request.
@@ -779,16 +771,8 @@ Arguments:
         block.
 
     Buffer - Supplies a pointer to a buffer to return the data block.
-
-
-Return Value:
-
-    NTSTATUS
-
 --*/
-
 {
-
     PSIMBATT_FDO_DATA DevExt;
     WDFDEVICE Device;
     NTSTATUS Status;
@@ -797,8 +781,6 @@ Return Value:
     UNREFERENCED_PARAMETER(InstanceCount);
 
     DebugEnter();
-    PAGED_CODE();
-
     ASSERT((InstanceIndex == 0) && (InstanceCount == 1));
 
     if (InstanceLengthArray == NULL) {

--- a/simbatt/wdf.c
+++ b/simbatt/wdf.c
@@ -36,7 +36,6 @@ WMI_QUERY_DATABLOCK_CALLBACK SimBattQueryWmiDataBlock;
 
 //---------------------------------------------------------------------- Pragmas
 
-#pragma alloc_text(PAGE, SimBattQueryStop)
 #pragma alloc_text(PAGE, SimBattDriverDeviceAdd)
 #pragma alloc_text(PAGE, SimBattDevicePrepareHardware)
 #pragma alloc_text(PAGE, SimBattWdmIrpPreprocessDeviceControl)
@@ -492,19 +491,13 @@ Routine Description:
     SimBatt circumvents this issue.
 
 Arguments:
-
     Device - Supplies a handle to a framework device object.
 
 Return Value:
-
     NTSTATUS
-
 --*/
-
 {
-
     UNREFERENCED_PARAMETER(Device);
-
     return STATUS_UNSUCCESSFUL;
 }
 

--- a/simbatt/wdf.c
+++ b/simbatt/wdf.c
@@ -36,7 +36,6 @@ WMI_QUERY_DATABLOCK_CALLBACK SimBattQueryWmiDataBlock;
 
 //---------------------------------------------------------------------- Pragmas
 
-#pragma alloc_text(PAGE, SimBattSelfManagedIoInit)
 #pragma alloc_text(PAGE, SimBattSelfManagedIoCleanup)
 #pragma alloc_text(PAGE, SimBattQueryStop)
 #pragma alloc_text(PAGE, SimBattDriverDeviceAdd)
@@ -350,8 +349,6 @@ Return Value:
     NTSTATUS Status;
 
     DebugEnter();
-    PAGED_CODE();
-
     DevExt = GetDeviceExtension(Device);
 
     //

--- a/simbatt/wdf.c
+++ b/simbatt/wdf.c
@@ -36,7 +36,6 @@ WMI_QUERY_DATABLOCK_CALLBACK SimBattQueryWmiDataBlock;
 
 //---------------------------------------------------------------------- Pragmas
 
-#pragma alloc_text(PAGE, SimBattSelfManagedIoCleanup)
 #pragma alloc_text(PAGE, SimBattQueryStop)
 #pragma alloc_text(PAGE, SimBattDriverDeviceAdd)
 #pragma alloc_text(PAGE, SimBattDevicePrepareHardware)
@@ -441,7 +440,6 @@ Return Value:
     NTSTATUS Status;
 
     DebugEnter();
-    PAGED_CODE();
 
     DeviceObject = WdfDeviceWdmGetDeviceObject(Device);
     Status = IoWMIRegistrationControl(DeviceObject, WMIREG_ACTION_DEREGISTER);

--- a/simbatt/wdf.c
+++ b/simbatt/wdf.c
@@ -36,7 +36,6 @@ WMI_QUERY_DATABLOCK_CALLBACK SimBattQueryWmiDataBlock;
 
 //---------------------------------------------------------------------- Pragmas
 
-#pragma alloc_text(PAGE, SimBattWdmIrpPreprocessDeviceControl)
 #pragma alloc_text(PAGE, SimBattWdmIrpPreprocessSystemControl)
 #pragma alloc_text(PAGE, SimBattQueryWmiRegInfo)
 #pragma alloc_text(PAGE, SimBattQueryWmiDataBlock)
@@ -548,9 +547,7 @@ SimBattWdmIrpPreprocessDeviceControl (
     )
 
 /*++
-
 Routine Description:
-
     This event is called when the framework receives IRP_MJ_DEVICE_CONTROL
     requests from the system.
 
@@ -561,23 +558,13 @@ Routine Description:
          requirement.
 
 Arguments:
-
     Device - Supplies a handle to a framework device object.
 
     Irp - Supplies the IO request being processed.
-
-Return Value:
-
-    NTSTATUS
-
 --*/
-
 {
-
     PSIMBATT_FDO_DATA DevExt;
     NTSTATUS Status;
-
-    PAGED_CODE();
     DebugEnter();
 
     ASSERTMSG("Must be called at IRQL = PASSIVE_LEVEL",
@@ -586,28 +573,18 @@ Return Value:
     DevExt = GetDeviceExtension(Device);
     Status = STATUS_NOT_SUPPORTED;
 
-    //
     // Suppress 28118:Irq Exceeds Caller, see Routine Description for
     // explaination.
-    //
-
     #pragma warning(suppress: 28118)
     WdfWaitLockAcquire(DevExt->ClassInitLock, NULL);
 
-    //
     // N.B. An attempt to queue the IRP with the port driver should happen
     //      before WDF assumes ownership of this IRP, i.e. before
     //      WdfDeviceWdmDispatchPreprocessedIrp is called, this is so that the
     //      Battery port driver, which is a WDM driver, may complete the IRP if
     //      it does endup procesing it.
-    //
-
     if (DevExt->ClassHandle != NULL) {
-
-        //
         // Suppress 28118:Irq Exceeds Caller, see above N.B.
-        //
-
         #pragma warning(suppress: 28118)
         Status = BatteryClassIoctl(DevExt->ClassHandle, Irp);
     }

--- a/simbatt/wdf.c
+++ b/simbatt/wdf.c
@@ -36,7 +36,6 @@ WMI_QUERY_DATABLOCK_CALLBACK SimBattQueryWmiDataBlock;
 
 //---------------------------------------------------------------------- Pragmas
 
-#pragma alloc_text(PAGE, SimBattDevicePrepareHardware)
 #pragma alloc_text(PAGE, SimBattWdmIrpPreprocessDeviceControl)
 #pragma alloc_text(PAGE, SimBattWdmIrpPreprocessSystemControl)
 #pragma alloc_text(PAGE, SimBattQueryWmiRegInfo)
@@ -530,17 +529,13 @@ Return Value:
 --*/
 
 {
-
-    NTSTATUS Status;
-
     UNREFERENCED_PARAMETER(ResourcesRaw);
     UNREFERENCED_PARAMETER(ResourcesTranslated);
 
     DebugEnter();
-    PAGED_CODE();
 
     SimBattPrepareHardware(Device);
-    Status = STATUS_SUCCESS;
+    NTSTATUS Status = STATUS_SUCCESS;
     DebugExitStatus(Status);
     return Status;
 }

--- a/simbatt/wdf.c
+++ b/simbatt/wdf.c
@@ -36,7 +36,6 @@ WMI_QUERY_DATABLOCK_CALLBACK SimBattQueryWmiDataBlock;
 
 //---------------------------------------------------------------------- Pragmas
 
-#pragma alloc_text(PAGE, SimBattDriverDeviceAdd)
 #pragma alloc_text(PAGE, SimBattDevicePrepareHardware)
 #pragma alloc_text(PAGE, SimBattWdmIrpPreprocessDeviceControl)
 #pragma alloc_text(PAGE, SimBattWdmIrpPreprocessSystemControl)
@@ -154,13 +153,9 @@ Arguments:
         structure.
 
 Return Value:
-
     NTSTATUS
-
 --*/
-
 {
-
     WDF_OBJECT_ATTRIBUTES DeviceAttributes;
     PSIMBATT_FDO_DATA DevExt;
     WDFDEVICE DeviceHandle;  
@@ -171,15 +166,10 @@ Return Value:
     NTSTATUS Status;
 
     UNREFERENCED_PARAMETER(Driver);
-
     DebugEnter();
-    PAGED_CODE();
 
-    //
     // Initialize the PnpPowerCallbacks structure.  Callback events for PNP
     // and Power are specified here.
-    //
-
     WDF_PNPPOWER_EVENT_CALLBACKS_INIT(&PnpPowerCallbacks);
     PnpPowerCallbacks.EvtDevicePrepareHardware = SimBattDevicePrepareHardware;
     PnpPowerCallbacks.EvtDeviceSelfManagedIoInit = SimBattSelfManagedIoInit;

--- a/simbatt/wdf.c
+++ b/simbatt/wdf.c
@@ -36,7 +36,6 @@ WMI_QUERY_DATABLOCK_CALLBACK SimBattQueryWmiDataBlock;
 
 //---------------------------------------------------------------------- Pragmas
 
-#pragma alloc_text(PAGE, SimBattWdmIrpPreprocessSystemControl)
 #pragma alloc_text(PAGE, SimBattQueryWmiRegInfo)
 #pragma alloc_text(PAGE, SimBattQueryWmiDataBlock)
 
@@ -605,11 +604,8 @@ SimBattWdmIrpPreprocessSystemControl (
     WDFDEVICE Device,
     PIRP Irp
     )
-
 /*++
-
 Routine Description:
-
     This event is called when the framework receives IRP_MJ_SYSTEM_CONTROL
     requests from the system.
 
@@ -620,41 +616,28 @@ Routine Description:
          requirement.
 
 Arguments:
-
     Device - Supplies a handle to a framework device object.
 
     Irp - Supplies the IO request being processed.
-
-Return Value:
-
-    NTSTATUS
-
 --*/
-
 {
-
     PSIMBATT_FDO_DATA DevExt;
     PDEVICE_OBJECT DeviceObject;
     SYSCTL_IRP_DISPOSITION Disposition;
     NTSTATUS Status;
 
     DebugEnter();
-    PAGED_CODE();
-
     ASSERTMSG("Must be called at IRQL = PASSIVE_LEVEL",(KeGetCurrentIrql() == PASSIVE_LEVEL));
 
     Status = STATUS_NOT_IMPLEMENTED;
     DevExt = GetDeviceExtension(Device);
     Disposition = IrpForward;
 
-    //
     // Acquire the class initialization lock and attempt to queue the IRP with
     // the class driver.
     //
     // Suppress 28118:Irq Exceeds Caller, see Routine Description for
     // explaination.
-    //
-
     #pragma warning(suppress: 28118)
     WdfWaitLockAcquire(DevExt->ClassInitLock, NULL);
     if (DevExt->ClassHandle != NULL) {

--- a/simbatt/wdf.c
+++ b/simbatt/wdf.c
@@ -36,7 +36,6 @@ WMI_QUERY_DATABLOCK_CALLBACK SimBattQueryWmiDataBlock;
 
 //---------------------------------------------------------------------- Pragmas
 
-#pragma alloc_text(INIT, DriverEntry)
 #pragma alloc_text(PAGE, SimBattSelfManagedIoInit)
 #pragma alloc_text(PAGE, SimBattSelfManagedIoCleanup)
 #pragma alloc_text(PAGE, SimBattQueryStop)


### PR DESCRIPTION
Done to simplify the driver by removing a lot of preprocessor flags and `PAGED_CODE()` calls that does not affect the functionality. 

The only downside of the changes is that the driver will end up consuming a few more kilobytes of RAM when loaded. The entire driver is 24kB large when built in release-mode, so the maximum RAM impact have to be less than that.