### PR TITLE
Auto-version the driver

### DIFF
--- a/BuildRelease.ps1
+++ b/BuildRelease.ps1
@@ -1,0 +1,26 @@
+# Script for building and packaging versioned releases of this project.
+# Run from "Developer PowerShell for VS 2022" from a commit with a git tag.
+
+# stop script on first error
+$ErrorActionPreference = "Stop"
+
+$p = Start-Process -FilePath "git.exe" -ArgumentList "tag --points-at HEAD" -NoNewWindow -Wait -RedirectStandardOutput  "tagname.txt"
+$tagname = Get-Content -Path "tagname.txt"
+if ($tagname -eq $null) {
+    throw "No git tag found for current commit"
+}
+
+$ver_tokens = $tagname.Split(".")
+while ($ver_tokens.Count -le 4) {
+    $ver_tokens += "0" # set patch & build to 0 if unspecified
+}
+$MajorVer = $ver_tokens[0].Substring(1) # remove "v" prefix
+$MinorVer = $ver_tokens[1]
+$PatchVer = $ver_tokens[2]
+$BuildVer = $ver_tokens[3]
+
+### Build solution in x64|Release
+msbuild /nologo /verbosity:minimal /property:Configuration="Release"`;Platform="x64"`;MajorVer=$MajorVer`;MinorVer=$MinorVer`;PatchVer=$PatchVer`;BuildVer=$BuildVer BatterySimulator.sln
+if ($LastExitCode -ne 0) {
+    throw "msbuild failure"
+}

--- a/simbatt/simbatt.rc
+++ b/simbatt/simbatt.rc
@@ -1,5 +1,9 @@
 #include <windows.h>
 
+// convert to string
+#define HSTR(str) #str
+#define STR(str) HSTR(str)
+
 // Required <common.ver> defines
 #ifdef _DEBUG
 #define VER_FILEFLAGS          VS_FF_DEBUG
@@ -9,8 +13,8 @@
 #define VER_FILEFLAGSMASK      VS_FFI_FILEFLAGSMASK
 #define VER_FILEOS             VOS_NT_WINDOWS32
 
-#define VER_PRODUCTVERSION        0,0,0,0
-#define VER_PRODUCTVERSION_STR    "0.0.0"
+#define VER_PRODUCTVERSION        MAJOR,MINOR,PATCH,BUILD
+#define VER_PRODUCTVERSION_STR    STR(MAJOR) "." STR(MINOR) "." STR(PATCH) "." STR(BUILD)
 #define	VER_FILETYPE	          VFT_DRV
 #define	VER_FILESUBTYPE	          VFT2_DRV_SYSTEM
 #define VER_COMPANYNAME_STR       "" // doesn't show up in file properties

--- a/simbatt/simbatt.vcxproj
+++ b/simbatt/simbatt.vcxproj
@@ -16,6 +16,10 @@
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
     <SampleGuid>{0D5B7AF0-B4D6-4392-8A7A-BC502932382B}</SampleGuid>
+    <MajorVer>0</MajorVer>
+    <MinorVer>0</MinorVer>
+    <PatchVer>0</PatchVer>
+    <BuildVer>0</BuildVer>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -69,7 +73,7 @@
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);..\..\inc</AdditionalIncludeDirectories>
     </Midl>
     <ResourceCompile>
-      <PreprocessorDefinitions>%(PreprocessorDefinitions);DRIVER;DEBUGPRINT</PreprocessorDefinitions>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);DRIVER;DEBUGPRINT;MAJOR=$(MajorVer);MINOR=$(MinorVer);PATCH=$(PatchVer);BUILD=$(BuildVer)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);..\..\inc</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
@@ -99,7 +103,7 @@ copy "C:\Program Files (x86)\Windows Kits\10\tools\$(WDKBuildFolder)\$(Platform)
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);..\..\inc</AdditionalIncludeDirectories>
     </Midl>
     <ResourceCompile>
-      <PreprocessorDefinitions>%(PreprocessorDefinitions);DRIVER;DEBUGPRINT</PreprocessorDefinitions>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);DRIVER;DEBUGPRINT;MAJOR=$(MajorVer);MINOR=$(MinorVer);PATCH=$(PatchVer);BUILD=$(BuildVer)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);..\..\inc</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
@@ -113,6 +117,11 @@ copy "C:\Program Files (x86)\Windows Kits\10\tools\$(WDKBuildFolder)\$(Platform)
 copy $(OutDir)\simbatt.cer $(PackageDir)
 copy "C:\Program Files (x86)\Windows Kits\10\tools\$(WDKBuildFolder)\$(Platform)\devgen.exe" $(PackageDir)</Command>
     </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(MajorVer)'!='0' Or '$(MinorVer)'!='0' Or '$(PatchVer)'!='0' Or '$(BuildVer)'!='0'">
+    <Inf>
+      <TimeStamp>$(MajorVer).$(MinorVer).$(PatchVer).$(BuildVer)</TimeStamp>
+    </Inf>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="miniclass.c" />


### PR DESCRIPTION
Task: Establish support for automatically versioning driver builds, based in git tags.

Subtasks:
* [x] Get version from git tag
* [x] Forward version to Visual Studio
* [x] Graceful fallback to default version
* [x] Apply version in INX/INF
* [x] Apply version in SYS

## Example
Example artifacts if building with `BuildRelease.ps1` from a `v3.14.15` tag:  
![image](https://github.com/forderud/BatterySimulator/assets/2671400/3ba1150a-577e-43fd-a42f-4156ceeb6bc7)
![image](https://github.com/forderud/BatterySimulator/assets/2671400/f2811bfd-962f-4f77-8721-20ea0940d099)

Manual developer builds from Visual Studio are not affected by the changes.