### PR TITLE
Also version MSI builds

### DIFF
--- a/BatterySimulatorMSI/BatterySimulatorMSI.wixproj
+++ b/BatterySimulatorMSI/BatterySimulatorMSI.wixproj
@@ -3,20 +3,25 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
+    <MajorVer>0</MajorVer>
+    <MinorVer>0</MinorVer>
+    <PatchVer>0</PatchVer>
+    <BuildVer>0</BuildVer>
     <ProductVersion>3.10</ProductVersion>
     <ProjectGuid>f33f1b5e-a173-4e5e-bdb7-9ce85898a712</ProjectGuid>
     <SchemaVersion>2.0</SchemaVersion>
-    <OutputName>BatterySimulator</OutputName>
+    <OutputName>BatterySimulator-$(MajorVer).$(MinorVer).$(PatchVer).$(BuildVer)</OutputName>
     <OutputType>Package</OutputType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug</DefineConstants>
+    <DefineConstants>Debug;Version=$(MajorVer).$(MinorVer).$(PatchVer).$(BuildVer)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
+    <DefineConstants>Version=$(MajorVer).$(MinorVer).$(PatchVer).$(BuildVer)</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Product.wxs" />

--- a/BatterySimulatorMSI/Product.wxs
+++ b/BatterySimulatorMSI/Product.wxs
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:difxapp='http://schemas.microsoft.com/wix/DifxAppExtension'>
-    <Product Id="*" Name="BatterySimulator" Language="1033" Version="1.0.0.0" Manufacturer="OpenSource" UpgradeCode="E1C79D1B-49A9-45F8-AC07-2762C3B20005">
+    <Product Id="*" Name="BatterySimulator" Language="1033" Version="$(var.Version)" Manufacturer="OpenSource" UpgradeCode="E1C79D1B-49A9-45F8-AC07-2762C3B20005">
         <Package InstallerVersion="500" Compressed="yes" InstallScope="perMachine" Description="Simulated battery driver" />
 
         <!-- Disable downgrades, prevent side-by-side installations of same version -->


### PR DESCRIPTION
Follow-up to #18

Subtasks:
* [x] Add version suffix to MSI filename
* [x] Version MSI installer
* [x] Graceful fallback for unversioned builds.

## Example
Installer created from a `v16.8.4.2` tag:
* Filename `BatterySimulator-16.8.4.2.msi`
* Installed version:
![image](https://github.com/forderud/BatterySimulator/assets/2671400/da1e48e2-9aca-4c6f-a137-262daa0087f3)

