### PR TITLE
Remove SIMBATT_STATE::Version field to simplify

### DIFF
--- a/simbatt/miniclass.c
+++ b/simbatt/miniclass.c
@@ -77,7 +77,6 @@ Arguments:
     {
         WdfWaitLockAcquire(DevExt->StateLock, NULL);
         SimBattUpdateTag(DevExt);
-        DevExt->State.Version = SIMBATT_STATE_VERSION;
         DevExt->State.BatteryStatus.PowerState = BATTERY_POWER_ON_LINE;
         DevExt->State.BatteryStatus.Capacity = 100;
         DevExt->State.BatteryStatus.Voltage = BATTERY_UNKNOWN_VOLTAGE;

--- a/simbatt/simbatt.h
+++ b/simbatt/simbatt.h
@@ -44,11 +44,7 @@ typedef struct {
     UNICODE_STRING                  RegistryPath;
 } SIMBATT_GLOBAL_DATA;
 
-#define SIMBATT_STATE_VERSION_1     1
-#define SIMBATT_STATE_VERSION       SIMBATT_STATE_VERSION_1
-
 typedef struct {
-    USHORT                          Version;
     BATTERY_MANUFACTURE_DATE        ManufactureDate;
     BATTERY_INFORMATION             BatteryInfo;
     BATTERY_STATUS                  BatteryStatus;


### PR DESCRIPTION
There's no plans for adding side-by-side support for multiple versions of this struct, so suggesting to remove it to simplify the implementation.