### PR TITLE
Stop using deprecated DifxApp extension for driver installation

### DIFF
--- a/BatterySimulatorMSI/BatterySimulatorMSI.wixproj
+++ b/BatterySimulatorMSI/BatterySimulatorMSI.wixproj
@@ -44,18 +44,6 @@
       <RefTargetDir>INSTALLFOLDER</RefTargetDir>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <WixLibrary Include="difxapp_x64">
-      <HintPath>$(WixExtDir)\difxapp_x64.wixlib</HintPath>
-      <Name>difxapp_x64</Name>
-    </WixLibrary>
-  </ItemGroup>
-  <ItemGroup>
-    <WixExtension Include="WixDifxAppExtension">
-      <HintPath>$(WixExtDir)\WixDifxAppExtension.dll</HintPath>
-      <Name>WixDifxAppExtension</Name>
-    </WixExtension>
-  </ItemGroup>
   <Import Project="$(WixTargetsPath)" Condition=" '$(WixTargetsPath)' != '' " />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets" Condition=" '$(WixTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets') " />
   <Target Name="EnsureWixToolsetInstalled" Condition=" '$(WixTargetsImported)' != 'true' ">

--- a/BatterySimulatorMSI/Product.wxs
+++ b/BatterySimulatorMSI/Product.wxs
@@ -14,10 +14,14 @@
 
         <CustomAction Id="AddCertToRoot" Directory="INSTALLFOLDER" ExeCommand="certutil.exe -addstore root &quot;[INSTALLFOLDER]simbatt.cer&quot;" Execute="deferred" Impersonate="no" />
         <CustomAction Id="AddCertToTrustedPublisher" Directory="INSTALLFOLDER" ExeCommand="certutil.exe -f -addstore trustedpublisher &quot;[INSTALLFOLDER]simbatt.cer&quot;" Execute="deferred" Impersonate="no" />
+        <CustomAction Id="InstallDriver" Directory="INSTALLFOLDER" ExeCommand="pnputil.exe /add-driver &quot;[INSTALLFOLDER]simbatt.inf&quot; /install" Execute="deferred" Impersonate="no" />
+        <CustomAction Id="UninstallDriver" Directory="INSTALLFOLDER" ExeCommand="pnputil.exe /delete-driver &quot;[INSTALLFOLDER]simbatt.inf&quot; /uninstall /force" Execute="deferred" Impersonate="no" />
 
         <InstallExecuteSequence>
-            <Custom Action="AddCertToRoot" Before="MsiProcessDrivers">NOT Installed OR REINSTALL</Custom>
-            <Custom Action="AddCertToTrustedPublisher" Before="MsiProcessDrivers">NOT Installed OR REINSTALL</Custom>
+            <Custom Action="AddCertToRoot" After="InstallFiles">NOT Installed OR REINSTALL</Custom>
+            <Custom Action="AddCertToTrustedPublisher" After="InstallFiles">NOT Installed OR REINSTALL</Custom>
+            <Custom Action="InstallDriver" After="InstallFiles">NOT Installed OR REINSTALL</Custom>
+            <Custom Action="UninstallDriver" After="InstallInitialize">REMOVE</Custom>
         </InstallExecuteSequence>
     </Product>
 

--- a/BatterySimulatorMSI/Product.wxs
+++ b/BatterySimulatorMSI/Product.wxs
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:difxapp='http://schemas.microsoft.com/wix/DifxAppExtension'>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product Id="*" Name="BatterySimulator" Language="1033" Version="$(var.Version)" Manufacturer="OpenSource" UpgradeCode="E1C79D1B-49A9-45F8-AC07-2762C3B20005">
         <Package InstallerVersion="500" Compressed="yes" InstallScope="perMachine" Description="Simulated battery driver" />
 
@@ -35,7 +35,6 @@
                 <File Id="simbatt.cer" Source="$(var.simbatt.TargetDir)simbatt\simbatt.cer" KeyPath="yes" />
             </Component>
             <Component Id="DriverFiles">
-                <difxapp:Driver Legacy="yes" PlugAndPlayPrompt="no" />
                 <File Id="simbatt.cat" Source="$(var.simbatt.TargetDir)simbatt\simbatt.cat" />
                 <File Id="simbatt.inf" Source="$(var.simbatt.TargetDir)simbatt\simbatt.inf" />
                 <File Id="simbatt.sys" Source="$(var.simbatt.TargetDir)simbatt\simbatt.sys" KeyPath="yes" Checksum="yes" />


### PR DESCRIPTION
Done to enable Wix5 upgrade of the MSI installer project, where DifxApp is no longer supported.