### PR TITLE
Add resource file with version metadata to EXE projects

### DIFF
--- a/BatteryQuery/BatteryQuery.vcxproj
+++ b/BatteryQuery/BatteryQuery.vcxproj
@@ -14,6 +14,10 @@
     <VCProjectVersion>17.0</VCProjectVersion>
     <ProjectGuid>{1802dab1-0769-4e39-bf84-e4f05c5ea917}</ProjectGuid>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <MajorVer>0</MajorVer>
+    <MinorVer>0</MinorVer>
+    <PatchVer>0</PatchVer>
+    <BuildVer>0</BuildVer>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
@@ -52,6 +56,9 @@
     <PostBuildEvent>
       <Command>signtool.exe sign /a /fd sha256 "$(TargetPath)"</Command>
     </PostBuildEvent>
+    <ResourceCompile>
+      <PreprocessorDefinitions>VERSION_MAJOR=$(MajorVer);VERSION_MINOR=$(MinorVer);VERSION_PATCH=$(PatchVer);VERSION_BUILD=$(BuildVer);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -73,6 +80,9 @@
     <PostBuildEvent>
       <Command>signtool.exe sign /a /fd sha256 "$(TargetPath)"</Command>
     </PostBuildEvent>
+    <ResourceCompile>
+      <PreprocessorDefinitions>VERSION_MAJOR=$(MajorVer);VERSION_MINOR=$(MinorVer);VERSION_PATCH=$(PatchVer);VERSION_BUILD=$(BuildVer);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="Main.cpp" />
@@ -80,6 +90,9 @@
   <ItemGroup>
     <ClInclude Include="Battery.hpp" />
     <ClInclude Include="DeviceInstance.hpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="module.rc" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/BatteryQuery/BatteryQuery.vcxproj.filters
+++ b/BatteryQuery/BatteryQuery.vcxproj.filters
@@ -7,4 +7,7 @@
     <ClInclude Include="Battery.hpp" />
     <ClInclude Include="DeviceInstance.hpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="module.rc" />
+  </ItemGroup>
 </Project>

--- a/BatteryQuery/module.rc
+++ b/BatteryQuery/module.rc
@@ -1,0 +1,40 @@
+#include <windows.h>
+
+// convert to string
+#define HSTR(str) #str
+#define STR(str) HSTR(str)
+
+#define VER_PRODUCTVERSION_STR    STR(VERSION_MAJOR) "." STR(VERSION_MINOR) "." STR(VERSION_PATCH) "." STR(VERSION_BUILD)
+
+VS_VERSION_INFO VERSIONINFO
+	FILEVERSION VERSION_MAJOR,VERSION_MINOR,VERSION_PATCH,VERSION_BUILD
+	PRODUCTVERSION VERSION_MAJOR,VERSION_MINOR,VERSION_PATCH,VERSION_BUILD
+	FILEFLAGSMASK 0x3fL
+#ifdef _DEBUG
+	FILEFLAGS VS_FF_DEBUG
+#else
+	FILEFLAGS 0x0L
+#endif
+	FILEOS VOS__WINDOWS32
+	FILETYPE VFT_APP
+	FILESUBTYPE 0x0L
+	BEGIN
+		BLOCK "StringFileInfo"
+		BEGIN
+			BLOCK "040904B0" /*0x0409=U.S. English, 0x04B0/1200=Unicode*/
+			BEGIN
+				VALUE "CompanyName", "forderud\0"
+				VALUE "FileDescription", "Battery parameter query\0"
+				VALUE "FileVersion", VER_PRODUCTVERSION_STR
+				VALUE "LegalCopyright", "Fredrik Orderud\0"
+				VALUE "OriginalFilename", "BatteryQuery.exe\0"
+				VALUE "ProductName", "BatteryQuery\0"
+				VALUE "ProductVersion", VER_PRODUCTVERSION_STR
+			END
+		END
+		BLOCK "VarFileInfo"
+		BEGIN
+			VALUE "Translation", 0x0409, 1200 /*0x0409=U.S. English, 0x04B0/1200=Unicode*/
+		END
+	END
+/* End of Version info */

--- a/DevicePowerQuery/DevicePowerQuery.vcxproj
+++ b/DevicePowerQuery/DevicePowerQuery.vcxproj
@@ -14,6 +14,10 @@
     <VCProjectVersion>17.0</VCProjectVersion>
     <ProjectGuid>{69fc5e7a-2743-4fbf-9621-763e43ce9e0f}</ProjectGuid>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <MajorVer>0</MajorVer>
+    <MinorVer>0</MinorVer>
+    <PatchVer>0</PatchVer>
+    <BuildVer>0</BuildVer>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
@@ -48,6 +52,9 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
+    <ResourceCompile>
+      <PreprocessorDefinitions>VERSION_MAJOR=$(MajorVer);VERSION_MINOR=$(MinorVer);VERSION_PATCH=$(PatchVer);VERSION_BUILD=$(BuildVer);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -65,6 +72,9 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
+    <ResourceCompile>
+      <PreprocessorDefinitions>VERSION_MAJOR=$(MajorVer);VERSION_MINOR=$(MinorVer);VERSION_PATCH=$(PatchVer);VERSION_BUILD=$(BuildVer);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="Main.cpp" />
@@ -73,6 +83,9 @@
     <ClInclude Include="DeviceEnum.hpp" />
     <ClInclude Include="DeviceParams.hpp" />
     <ClInclude Include="PowerData.hpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="module.rc" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/DevicePowerQuery/DevicePowerQuery.vcxproj.filters
+++ b/DevicePowerQuery/DevicePowerQuery.vcxproj.filters
@@ -8,4 +8,7 @@
     <ClInclude Include="PowerData.hpp" />
     <ClInclude Include="DeviceEnum.hpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="module.rc" />
+  </ItemGroup>
 </Project>

--- a/DevicePowerQuery/module.rc
+++ b/DevicePowerQuery/module.rc
@@ -1,0 +1,40 @@
+#include <windows.h>
+
+// convert to string
+#define HSTR(str) #str
+#define STR(str) HSTR(str)
+
+#define VER_PRODUCTVERSION_STR    STR(VERSION_MAJOR) "." STR(VERSION_MINOR) "." STR(VERSION_PATCH) "." STR(VERSION_BUILD)
+
+VS_VERSION_INFO VERSIONINFO
+	FILEVERSION VERSION_MAJOR,VERSION_MINOR,VERSION_PATCH,VERSION_BUILD
+	PRODUCTVERSION VERSION_MAJOR,VERSION_MINOR,VERSION_PATCH,VERSION_BUILD
+	FILEFLAGSMASK 0x3fL
+#ifdef _DEBUG
+	FILEFLAGS VS_FF_DEBUG
+#else
+	FILEFLAGS 0x0L
+#endif
+	FILEOS VOS__WINDOWS32
+	FILETYPE VFT_APP
+	FILESUBTYPE 0x0L
+	BEGIN
+		BLOCK "StringFileInfo"
+		BEGIN
+			BLOCK "040904B0" /*0x0409=U.S. English, 0x04B0/1200=Unicode*/
+			BEGIN
+				VALUE "CompanyName", "forderud\0"
+				VALUE "FileDescription", "Device power query\0"
+				VALUE "FileVersion", VER_PRODUCTVERSION_STR
+				VALUE "LegalCopyright", "Fredrik Orderud\0"
+				VALUE "OriginalFilename", "DevicePowerQuery.exe\0"
+				VALUE "ProductName", "DevicePowerQuery\0"
+				VALUE "ProductVersion", VER_PRODUCTVERSION_STR
+			END
+		END
+		BLOCK "VarFileInfo"
+		BEGIN
+			VALUE "Translation", 0x0409, 1200 /*0x0409=U.S. English, 0x04B0/1200=Unicode*/
+		END
+	END
+/* End of Version info */

--- a/PowerMonitor/PowerMonitor.vcxproj
+++ b/PowerMonitor/PowerMonitor.vcxproj
@@ -14,6 +14,10 @@
     <VCProjectVersion>17.0</VCProjectVersion>
     <ProjectGuid>{c4c362f7-890a-4957-9cac-084fcfa9bdc6}</ProjectGuid>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <MajorVer>0</MajorVer>
+    <MinorVer>0</MinorVer>
+    <PatchVer>0</PatchVer>
+    <BuildVer>0</BuildVer>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
@@ -49,6 +53,9 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
+    <ResourceCompile>
+      <PreprocessorDefinitions>VERSION_MAJOR=$(MajorVer);VERSION_MINOR=$(MinorVer);VERSION_PATCH=$(PatchVer);VERSION_BUILD=$(BuildVer);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -67,9 +74,15 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
+    <ResourceCompile>
+      <PreprocessorDefinitions>VERSION_MAJOR=$(MajorVer);VERSION_MINOR=$(MinorVer);VERSION_PATCH=$(PatchVer);VERSION_BUILD=$(BuildVer);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="Main.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="module.rc" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/PowerMonitor/PowerMonitor.vcxproj.filters
+++ b/PowerMonitor/PowerMonitor.vcxproj.filters
@@ -3,4 +3,7 @@
   <ItemGroup>
     <ClCompile Include="Main.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="module.rc" />
+  </ItemGroup>
 </Project>

--- a/PowerMonitor/module.rc
+++ b/PowerMonitor/module.rc
@@ -1,0 +1,40 @@
+#include <windows.h>
+
+// convert to string
+#define HSTR(str) #str
+#define STR(str) HSTR(str)
+
+#define VER_PRODUCTVERSION_STR    STR(VERSION_MAJOR) "." STR(VERSION_MINOR) "." STR(VERSION_PATCH) "." STR(VERSION_BUILD)
+
+VS_VERSION_INFO VERSIONINFO
+	FILEVERSION VERSION_MAJOR,VERSION_MINOR,VERSION_PATCH,VERSION_BUILD
+	PRODUCTVERSION VERSION_MAJOR,VERSION_MINOR,VERSION_PATCH,VERSION_BUILD
+	FILEFLAGSMASK 0x3fL
+#ifdef _DEBUG
+	FILEFLAGS VS_FF_DEBUG
+#else
+	FILEFLAGS 0x0L
+#endif
+	FILEOS VOS__WINDOWS32
+	FILETYPE VFT_APP
+	FILESUBTYPE 0x0L
+	BEGIN
+		BLOCK "StringFileInfo"
+		BEGIN
+			BLOCK "040904B0" /*0x0409=U.S. English, 0x04B0/1200=Unicode*/
+			BEGIN
+				VALUE "CompanyName", "forderud\0"
+				VALUE "FileDescription", "Power event monitor\0"
+				VALUE "FileVersion", VER_PRODUCTVERSION_STR
+				VALUE "LegalCopyright", "Fredrik Orderud\0"
+				VALUE "OriginalFilename", "PowerMonitor.exe\0"
+				VALUE "ProductName", "PowerMonitor\0"
+				VALUE "ProductVersion", VER_PRODUCTVERSION_STR
+			END
+		END
+		BLOCK "VarFileInfo"
+		BEGIN
+			VALUE "Translation", 0x0409, 1200 /*0x0409=U.S. English, 0x04B0/1200=Unicode*/
+		END
+	END
+/* End of Version info */


### PR DESCRIPTION
Default to version `0.0.0.0` unless a version is passed as `MajorVer=$MajorVer`;MinorVer=$MinorVer`;PatchVer=$PatchVer`;BuildVer=$BuildVer` as msbuild command-line argument.

Screenshot of sample build with mocked version:  
![image](https://github.com/user-attachments/assets/dde4eb50-bd1e-45dc-a25c-8426dbb00aa1)
