### PR TITLE
Set /brepro option for deterministic builds

### DIFF
--- a/simbatt/simbatt.vcxproj
+++ b/simbatt/simbatt.vcxproj
@@ -78,6 +78,7 @@
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);battc.lib</AdditionalDependencies>
+      <AdditionalOptions>/brepro %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
@@ -108,6 +109,7 @@ copy "C:\Program Files (x86)\Windows Kits\10\tools\$(WDKBuildFolder)\$(Platform)
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);battc.lib</AdditionalDependencies>
+      <AdditionalOptions>/brepro %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>


### PR DESCRIPTION
This undocumented linker flag will set all timestamps in the Portable Executable file to -1 as documented on https://blog.conan.io/2019/09/02/Deterministic-builds-with-C-C++.html . This will improve traceability between compiled driver binaries and the source code used to generate them.

Please note that the cryptographic signature may still differ between builds if using a time server or different signatures. This is expected and can be worked around by removing the signatures with `signtool.exe remove /s simbatt.sys` before comparing.