### PR TITLE
Set /brepro option for deterministic builds

### DIFF
--- a/BatteryQuery/BatteryQuery.vcxproj
+++ b/BatteryQuery/BatteryQuery.vcxproj
@@ -52,6 +52,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalOptions>/brepro %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <PostBuildEvent>
       <Command>signtool.exe sign /a /fd sha256 "$(TargetPath)"</Command>
@@ -76,6 +77,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalOptions>/brepro %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <PostBuildEvent>
       <Command>signtool.exe sign /a /fd sha256 "$(TargetPath)"</Command>

--- a/DevicePowerQuery/DevicePowerQuery.vcxproj
+++ b/DevicePowerQuery/DevicePowerQuery.vcxproj
@@ -51,6 +51,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalOptions>/brepro %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <ResourceCompile>
       <PreprocessorDefinitions>VERSION_MAJOR=$(MajorVer);VERSION_MINOR=$(MinorVer);VERSION_PATCH=$(PatchVer);VERSION_BUILD=$(BuildVer);%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -71,6 +72,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalOptions>/brepro %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <ResourceCompile>
       <PreprocessorDefinitions>VERSION_MAJOR=$(MajorVer);VERSION_MINOR=$(MinorVer);VERSION_PATCH=$(PatchVer);VERSION_BUILD=$(BuildVer);%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/PowerMonitor/PowerMonitor.vcxproj
+++ b/PowerMonitor/PowerMonitor.vcxproj
@@ -52,6 +52,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalOptions>/brepro %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <ResourceCompile>
       <PreprocessorDefinitions>VERSION_MAJOR=$(MajorVer);VERSION_MINOR=$(MinorVer);VERSION_PATCH=$(PatchVer);VERSION_BUILD=$(BuildVer);%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -73,6 +74,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalOptions>/brepro %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <ResourceCompile>
       <PreprocessorDefinitions>VERSION_MAJOR=$(MajorVer);VERSION_MINOR=$(MinorVer);VERSION_PATCH=$(PatchVer);VERSION_BUILD=$(BuildVer);%(PreprocessorDefinitions)</PreprocessorDefinitions>


### PR DESCRIPTION
Follow-up to #52 that also updates the non-driver projects.

This undocumented linker flag will set all timestamps in the Portable Executable file to -1 as documented on https://blog.conan.io/2019/09/02/Deterministic-builds-with-C-C++.html . This will improve traceability between compiled driver binaries and the source code used to generate them.