### PR TITLE
Try to reproduce  "critical thermal event" (doesn't work)

### DIFF
--- a/simbatt/battery.cpp
+++ b/simbatt/battery.cpp
@@ -110,10 +110,10 @@ Arguments:
         DevExt->State.BatteryInfo.CriticalBias = 0;
         DevExt->State.BatteryInfo.CycleCount = 100;
 
-        DevExt->State.BatteryStatus.PowerState = BATTERY_POWER_ON_LINE;
+        DevExt->State.BatteryStatus.PowerState = BATTERY_DISCHARGING | BATTERY_CRITICAL;
         DevExt->State.BatteryStatus.Capacity = 5*1000; // [mWh]
         DevExt->State.BatteryStatus.Voltage = 15000; // [mV]
-        DevExt->State.BatteryStatus.Rate = BATTERY_UNKNOWN_RATE; // >0 when charging and <0 when discharging [mW]
+        DevExt->State.BatteryStatus.Rate = -20*1000; // >0 when charging and <0 when discharging [mW]
 
         //DevExt->State.GranularityCount = 0;
         //for (unsigned int i = 0; i < DevExt->State.GranularityCount; ++i) {

--- a/simbatt/battery.cpp
+++ b/simbatt/battery.cpp
@@ -123,7 +123,7 @@ Arguments:
 
         DevExt->State.EstimatedTime = BATTERY_UNKNOWN_TIME; // battery run time, in seconds
 
-        DevExt->State.Temperature = 2981; // 25 degree Celsius [10ths of a degree Kelvin]
+        DevExt->State.Temperature = 999*10; // [10ths of a degree Kelvin]
 
         RtlStringCchCopyW(DevExt->State.DeviceName, MAX_BATTERY_STRING_SIZE, L"SimulatedBattery");
 


### PR DESCRIPTION
Attempt to reproduce #56 by setting [BATTERY_STATUS](https://learn.microsoft.com/en-us/windows/win32/power/battery-status-str) `PowerState=BATTERY_CRITICAL`  and increasing cell temperature to 999 Kelvin. Still, nothing special seem to happen.

Battery parameters exposed:  
![image](https://github.com/user-attachments/assets/669ed1a1-5551-418b-808f-624af310d7f5)  


`Kernel-Power` events produced:  
![image](https://github.com/user-attachments/assets/401f60e4-59c4-4b57-8323-a9a0c904b30c)
